### PR TITLE
x86 architecture independent code

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -81,7 +81,7 @@ quick:
 	$(MAKE) target=UNIX \
 		CC=clang \
  		opt='-DSYZYGY -DTRACE -DCPUS=12' \
-		CFLAGS='-Wall -mpopcnt -Wno-array-bounds -pipe -O3' \
+		CFLAGS+='-Wall -Wno-array-bounds -pipe -O3' \
 		LDFLAGS='$(LDFLAGS) -lstdc++' \
 		crafty-make
 
@@ -89,8 +89,8 @@ unix-gcc:
 	$(MAKE) -j target=UNIX \
 		CC=gcc \
 		opt='-DSYZYGY -DCPUS=12' \
-		CFLAGS='-Wall -Wno-array-bounds -pipe -O3 -fprofile-use \
-		-mpopcnt -fprofile-correction -pthread' \
+		CFLAGS+='-Wall -Wno-array-bounds -pipe -O3 -fprofile-use \
+		-fprofile-correction -pthread' \
 		LDFLAGS='$(LDFLAGS) -fprofile-use -pthread -lstdc++' \
 		crafty-make
 
@@ -98,8 +98,8 @@ unix-gcc-profile:
 	$(MAKE) -j target=UNIX \
 		CC=gcc \
 		opt='-DSYZYGY -DCPUS=12' \
-		CFLAGS='-Wall -Wno-array-bounds -pipe -O3 -fprofile-arcs \
-		-mpopcnt -pthread' \
+		CFLAGS+='-Wall -Wno-array-bounds -pipe -O3 -fprofile-arcs \
+			-pthread' \
 		LDFLAGS='$(LDFLAGS) -fprofile-arcs -pthread -lstdc++ ' \
 		crafty-make
 
@@ -108,8 +108,8 @@ unix-clang:
 	$(MAKE) -j target=UNIX \
 		CC=clang \
 		opt='-DELO -DSYZYGY -DCPUS=12' \
-		CFLAGS='-Wall -Wno-array-bounds -pipe -O3 \
-			-mpopcnt -fprofile-instr-use=crafty.profdata' \
+		CFLAGS+='-Wall -Wno-array-bounds -pipe -O3 \
+			-fprofile-instr-use=crafty.profdata' \
 		LDFLAGS='$(LDFLAGS) -fprofile-use -lstdc++' \
 		crafty-make
 
@@ -117,8 +117,8 @@ unix-clang-profile:
 	$(MAKE) -j target=UNIX \
 		CC=clang \
 		opt='-DELO -DSYZYGY -DCPUS=12' \
-		CFLAGS='-Wall -Wno-array-bounds -pipe -O3 \
-			-mpopcnt -fprofile-instr-generate' \
+		CFLAGS+='-Wall -Wno-array-bounds -pipe -O3 \
+			-fprofile-instr-generate' \
 		LDFLAGS='$(LDFLAGS) -fprofile-instr-generate -lstdc++ ' \
 		crafty-make
 
@@ -126,8 +126,8 @@ unix-icc:
 	$(MAKE) -j target=UNIX \
 		CC=icc \
 		opt='-DSYZYGY -DCPUS=4' \
-		CFLAGS='-Wall -w -O2 -prof_use -prof_dir ./prof -fno-alias \
-                        -mpopcnt -pthread' \
+		CFLAGS+='-Wall -w -O2 -prof_use -prof_dir ./prof -fno-alias \
+                        -pthread' \
 		LDFLAGS='$(LDFLAGS) -pthread -lstdc++' \
 		crafty-make
 
@@ -135,8 +135,8 @@ unix-icc-profile:
 	$(MAKE) -j target=UNIX \
 		CC=icc \
 		opt='-DSYZYGY -DCPUS=12' \
-		CFLAGS='-Wall -w -O2 -prof_gen -prof_dir ./prof -fno-alias \
-                        -mpopcnt -pthread' \
+		CFLAGS+='-Wall -w -O2 -prof_gen -prof_dir ./prof -fno-alias \
+                        -pthread' \
 		LDFLAGS='$(LDFLAGS) -pthread -lstdc++ ' \
 		crafty-make
 

--- a/src/lock.h
+++ b/src/lock.h
@@ -41,40 +41,11 @@ void Pause() {
  *                                                                             *
  *******************************************************************************
  */
-static void __inline__ LockX86(volatile int *lock) {
-  int dummy;
-  asm __volatile__(
-      "1:          movl    $1, %0"          "\n\t"
-      "            xchgl   (%1), %0"        "\n\t"
-      "            testl   %0, %0"          "\n\t"
-      "            jz      3f"              "\n\t"
-      "2:          pause"                   "\n\t"
-      "            movl    (%1), %0"        "\n\t"
-      "            testl   %0, %0"          "\n\t"
-      "            jnz     2b"              "\n\t"
-      "            jmp     1b"              "\n\t"
-      "3:"                                  "\n\t"
-      :"=&q"(dummy)
-      :"q"(lock)
-      :"cc", "memory");
-}
-static void __inline__ Pause() {
-  asm __volatile__(
-      "            pause"                   "\n\t");
-}
-static void __inline__ UnlockX86(volatile int *lock) {
-  asm __volatile__(
-      "movl        $0, (%0)"
-      :
-      :"q"(lock)
-      :"memory");
-}
-
-#    define LockInit(p)           (p=0)
-#    define LockFree(p)           (p=0)
-#    define Unlock(p)             (UnlockX86(&p))
-#    define Lock(p)               (LockX86(&p))
-#    define lock_t                volatile int
+#    include <pthread.h>
+#    define lock_t                pthread_mutex_t
+#    define LockInit(p)           (pthread_mutex_init(&p, NULL))
+#    define Unlock(p)             (pthread_mutex_unlock(&p))
+#    define Lock(p)               (pthread_mutex_lock(&p))
 #  endif
 #else
 #  define LockInit(p)


### PR DESCRIPTION
The aim of the modification is the possibility to compile Crafty for other architectures besides x86. The modification has been tested on aarch64 (Raspberry pi 4B) and riscv64(Starfive Visionfive 2) (all under Linux) in addition to x86.
A change in the Makefile allows custom CFLAGS to be used in the make command and x86 dependent flag.
A change in lock.h removes x86 dependent code.